### PR TITLE
make Value move-constructor distinct from Value constructor

### DIFF
--- a/test_polymorphic_value.cpp
+++ b/test_polymorphic_value.cpp
@@ -93,7 +93,7 @@ TEST_CASE("Value move-constructor", "[polymorphic_value.constructors]")
 {
   DerivedType d(7);
 
-  polymorphic_value<BaseType> i(d);
+  polymorphic_value<BaseType> i(std::move(d));
 
   REQUIRE(i->value() == 7);
 }


### PR DESCRIPTION
Hi,

I think you overlooked this little test and its probably the smartest thing I can contribute.

Regards,

Stein