### PR TITLE
Add Boost documentation skeleton.

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -1,0 +1,98 @@
+# Distributed under the Boost Software License, Version 1.0. (See
+# accomanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt
+
+import path ;
+import doxygen ;
+import quickbook ;
+
+using auto-index ;
+using doxygen ;
+using quickbook ;
+using boostbook ;
+
+rule run_doxygen ( files * : name : expand ? )
+{
+
+    expand ?= <doxygen:param>EXPAND_ONLY_PREDEF=YES ;
+
+doxygen polymorphic_value_reference
+  :
+    $(files)
+  :
+        <doxygen:param>EXTRACT_ALL=YES
+        # note that there is no detail::unspecified -- this is a hack to get all
+        # the SFINAE code out of the API docs.
+        <doxygen:param>"PREDEFINED=\"BOOST_POLYMORPHIC_VALUE_DOXYGEN=1\""
+        <doxygen:param>HIDE_UNDOC_MEMBERS=NO
+        <doxygen:param>EXTRACT_PRIVATE=NO
+        <doxygen:param>ENABLE_PREPROCESSING=YES
+        <doxygen:param>MACRO_EXPANSION=YES
+        $(expand)
+        <doxygen:param>SEARCH_INCLUDES=NO
+        <doxygen:param>EXAMPLE_PATH=.
+        <reftitle>$(name)
+  ;
+
+}
+
+run_doxygen [ glob ../*.h ] : "Reference" ;
+
+xml polymorphic_value
+    :
+        polymorphic_value.qbk
+    ;
+
+boostbook standalone
+    :
+        polymorphic_value
+    :
+        <dependency>css
+        <dependency>images
+
+        <dependency>polymorphic_value_reference
+
+        # HTML options first:
+        # Use graphics not text for navigation:
+        <xsl:param>navig.graphics=1
+        # How far down we chunk nested sections, basically all of them:
+        <xsl:param>chunk.section.depth=10
+        # Don't put the first section on the same page as the TOC:
+        <xsl:param>chunk.first.sections=1
+        # How far down sections get TOC's
+        <xsl:param>toc.section.depth=10
+        # Max depth in each TOC:
+        <xsl:param>toc.max.depth=4
+        # How far down we go with TOC's
+        <xsl:param>generate.section.toc.level=10
+        # Set the path to the boost-root so we find our graphics:
+        #<xsl:param>boost.root="../../../.."
+        # location of the main index file so our links work:
+        #<xsl:param>boost.libraries=../../../../../libs/libraries.htm
+
+        # PDF Options:
+        # TOC Generation: this is needed for FOP-0.9 and later:
+        # <xsl:param>fop1.extensions=1
+        <xsl:param>xep.extensions=1
+        # TOC generation: this is needed for FOP 0.2, but must not be set to zero for FOP-0.9!
+        <xsl:param>fop.extensions=0
+        # No indent on body text:
+        <xsl:param>body.start.indent=0pt
+        # Margin size:
+        <xsl:param>page.margin.inner=0.5in
+        # Margin size:
+        <xsl:param>page.margin.outer=0.5in
+        # Yes, we want graphics for admonishments:
+        <xsl:param>admon.graphics=1
+        # Set this one for PDF generation *only*:
+        # default pnd graphics are awful in PDF form,
+        # better use SVG's instead:
+        # <xsl:param>admon.graphics.extension=".svg"
+    ;
+
+install css : [ glob $(BOOST_ROOT)/doc/src/*.css ]
+    : <location>html ;
+install images : [ glob $(BOOST_ROOT)/doc/src/images/*.png ]
+    : <location>html/images ;
+explicit css ;
+explicit images ;

--- a/doc/Jamroot.jam
+++ b/doc/Jamroot.jam
@@ -1,0 +1,45 @@
+#
+#   Copyright (c) 2006 João Abecasis
+#
+#   Distributed under the Boost Software License, Version 1.0. (See
+#   accompanying file LICENSE_1_0.txt or copy at
+#   http://www.boost.org/LICENSE_1_0.txt)
+#
+
+##
+##  IMPORTANT NOTE: This file MUST NOT be copied over a boost installation
+##
+
+path-constant top : . ;
+
+import modules ;
+import path ;
+
+local boost-root = [ modules.peek : BOOST_ROOT ] ;
+
+if ! $(boost-root)
+{
+    local boost-search-dirs = [ modules.peek : BOOST_BUILD_PATH ] ;
+
+    for local dir in $(boost-search-dirs)
+    {
+        if [ path.glob $(dir)/../../../ : boost/version.hpp ]
+        {
+            boost-root += $(dir)/../../../ ;
+        }
+    }
+
+    if $(boost-root)
+    {
+        boost-root = [ path.make $(boost-root[1]) ] ;
+    }
+    else
+    {
+        ECHO "Warning: couldn't find BOOST_ROOT in" $(boost-root) ;
+    }
+}
+
+path-constant BOOST_ROOT : $(boost-root) ;
+modules.poke : QUICKBOOK_ROOT : $(top) ;
+
+use-project /boost : $(BOOST_ROOT) ;

--- a/doc/intro.qbk
+++ b/doc/intro.qbk
@@ -1,0 +1,9 @@
+[section Introduction]
+
+TODO
+
+[heading Motivation]
+
+TODO
+
+[endsect]

--- a/doc/polymorphic_value.qbk
+++ b/doc/polymorphic_value.qbk
@@ -1,0 +1,40 @@
+[/
+ / Distributed under the Boost Software License, Version 1.0. (See accompanying
+ / file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ /]
+
+[library Boost.PolymorphicValue (Proposed)
+    [quickbook 1.3]
+    [authors [Coe, Jonathan]]
+    [copyright 2017 Jonathan Coe]
+    [category template]
+    [id polymorphic_value]
+    [dirname polymorphic_value]
+    [purpose
+        A polymorphic value-type for C++ targeting standardization.
+    ]
+    [license
+        Distributed under the Boost Software License, Version 1.0.
+        (See accompanying file LICENSE_1_0.txt or copy at
+        [@http://www.boost.org/LICENSE_1_0.txt])
+    ]
+]
+
+[/ QuickBook Document version 1.3 ]
+
+[/ Imports ]
+
+
+[/ Images ]
+
+[def __note__              [$images/note.png]]
+[def __tip__               [$images/tip.png]]
+[def __important__         [$images/important.png]]
+[def __caution__           [$images/caution.png]]
+[def __warning__           [$images/warning.png]]
+
+[/ Links ]
+
+[include intro.qbk]
+
+[xinclude polymorphic_value_reference.xml]


### PR DESCRIPTION
To build the docs, go into doc/, and execute:

BOOST_ROOT=~/boost_1_62_0 ~/boost_1_62_0/b2

Assuming:
1) You're using Boost 1.62.
2) It's in your home dir.
3) It has already been bootstrapped with bootstrap.sh.