### PR TITLE
Fix some compiler warnings observed with gcc-9:

### DIFF
--- a/polymorphic_value.h
+++ b/polymorphic_value.h
@@ -361,7 +361,7 @@ namespace jbcoe
 
     explicit operator bool() const
     {
-      return (bool)cb_;
+      return bool (cb_);
     }
 
     const T* operator->() const
@@ -399,7 +399,7 @@ namespace jbcoe
     p.cb_ = std::make_unique<detail::direct_control_block<T, T>>(
         std::forward<Ts>(ts)...);
     p.ptr_ = p.cb_->ptr();
-    return std::move(p);
+    return p;
   }
   template <class T, class U, class... Ts>
   polymorphic_value<T> make_polymorphic_value(Ts&&... ts)
@@ -408,7 +408,7 @@ namespace jbcoe
     p.cb_ = std::make_unique<detail::direct_control_block<T, U>>(
         std::forward<Ts>(ts)...);
     p.ptr_ = p.cb_->ptr();
-    return std::move(p);
+    return p;
   }
 
   //


### PR DESCRIPTION
polymorphic_value.h: In member function 'jbcoe::polymorphic_value<T>::operator bool() const':
polymorphic_value.h:364:20: error: use of old-style cast to 'bool' [-Werror=old-style-cast]
polymorphic_value.h: In instantiation of 'jbcoe::polymorphic_value<T> jbcoe::make_polymorphic_value(Ts&& ...)':
polymorphic_value.h:411:23: error: moving a local object in a return statement prevents copy elision [-Werror=pessimizing-move]
polymorphic_value.h:411:23:  note: remove 'std::move' call