### PR TITLE
Ensure x86 builds fetch x86 MinGW installer

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,11 +7,17 @@ environment:
   PYTHON_HOME: "C:\\Python37"
   matrix:
       - MINGW_CONFIGURATIONS: '6@x86@dwarf2@posix'
+        CONAN_ARCHS: x86
       - MINGW_CONFIGURATIONS: '6@x86_64@seh@posix'
+        CONAN_ARCHS: x86_64
       - MINGW_CONFIGURATIONS: '7@x86@dwarf2@posix'
+        CONAN_ARCHS: x86
       - MINGW_CONFIGURATIONS: '7@x86_64@seh@posix'
+        CONAN_ARCHS: x86_64
       - MINGW_CONFIGURATIONS: '8@x86@dwarf2@posix'
+        CONAN_ARCHS: x86
       - MINGW_CONFIGURATIONS: '8@x86_64@seh@posix'
+        CONAN_ARCHS: x86_64
       - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
         CONAN_VISUAL_VERSIONS: 15
         CONAN_BUILD_TYPES: Release

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,18 +6,12 @@ environment:
   CONAN_PRINT_RUN_COMMANDS: 1
   PYTHON_HOME: "C:\\Python37"
   matrix:
-      - MINGW_CONFIGURATIONS: '6@x86@dwarf2@posix'
-        CONAN_ARCHS: x86
+      - MINGW_CONFIGURATIONS: '6@x86@sjlj@posix'
       - MINGW_CONFIGURATIONS: '6@x86_64@seh@posix'
-        CONAN_ARCHS: x86_64
-      - MINGW_CONFIGURATIONS: '7@x86@dwarf2@posix'
-        CONAN_ARCHS: x86
+      - MINGW_CONFIGURATIONS: '7@x86@sjlj@posix'
       - MINGW_CONFIGURATIONS: '7@x86_64@seh@posix'
-        CONAN_ARCHS: x86_64
-      - MINGW_CONFIGURATIONS: '8@x86@dwarf2@posix'
-        CONAN_ARCHS: x86
+      - MINGW_CONFIGURATIONS: '8@x86@sjlj@posix'
       - MINGW_CONFIGURATIONS: '8@x86_64@seh@posix'
-        CONAN_ARCHS: x86_64
       - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
         CONAN_VISUAL_VERSIONS: 15
         CONAN_BUILD_TYPES: Release


### PR DESCRIPTION
Looks like the x86 versions of MinGW are failing when incorrectly trying to get the x86_64 architecture build of the MinGW installer.  This make sense because Darwf exception handling is not support for x86_64 architecture.  However, the root cause is that it is incorrectly defaulting to x86_64 architecute dependencies for the x86 build.