### PR TITLE
Combine make_polymorphic_value functions to avoid ambiguity

### DIFF
--- a/polymorphic_value.h
+++ b/polymorphic_value.h
@@ -145,8 +145,6 @@ class polymorphic_value {
 
   template <class T_, class U, class... Ts>
   friend polymorphic_value<T_> make_polymorphic_value(Ts&&... ts);
-  template <class T_, class... Ts>
-  friend polymorphic_value<T_> make_polymorphic_value(Ts&&... ts);
 
   T* ptr_ = nullptr;
   std::unique_ptr<detail::control_block<T>> cb_;
@@ -323,15 +321,7 @@ class polymorphic_value {
 //
 // polymorphic_value creation
 //
-template <class T, class... Ts>
-polymorphic_value<T> make_polymorphic_value(Ts&&... ts) {
-  polymorphic_value<T> p;
-  p.cb_ = std::make_unique<detail::direct_control_block<T, T>>(
-      std::forward<Ts>(ts)...);
-  p.ptr_ = p.cb_->ptr();
-  return p;
-}
-template <class T, class U, class... Ts>
+template <class T, class U = T, class... Ts>
 polymorphic_value<T> make_polymorphic_value(Ts&&... ts) {
   polymorphic_value<T> p;
   p.cb_ = std::make_unique<detail::direct_control_block<T, U>>(

--- a/polymorphic_value_test.cpp
+++ b/polymorphic_value_test.cpp
@@ -501,6 +501,20 @@ TEST_CASE("make_polymorphic_value with two template arguments",
   REQUIRE(pv->value() == 7);
 }
 
+struct B;
+struct A {
+  A(B);
+  A() = default;
+};
+struct B : A {};
+
+TEST_CASE("make_polymorphic_value ambiguity",
+          "[polymorphic_value.make_polymorphic_value.ambiguity]") {
+  B b;
+  // This was ambiguous with two make_polymorphic_value functions.
+  auto pv = make_polymorphic_value<A, B>(b);
+}
+
 TEST_CASE("Derived types", "[polymorphic_value.derived_types]") {
   GIVEN(
       "A polymorphic_value<BaseType> constructed from "


### PR DESCRIPTION
Thanks to Anthony Williams for spotting the problem with ambiguous overloads.