### PR TITLE
Introduce copier_traits

### DIFF
--- a/polymorphic_value_test.cpp
+++ b/polymorphic_value_test.cpp
@@ -677,6 +677,7 @@ TEST_CASE("Exception safety: throw in copy constructor",
 
 template <typename T>
 struct throwing_copier {
+  using deleter_type = std::default_delete<T>;
   T* operator()(const T& t) const { throw std::bad_alloc{}; }
 };
 


### PR DESCRIPTION
As per https://github.com/jbcoe/indirect_value/pull/96

Use std::default_delete, move default_copy out of detail to permit
specialization.

Remove (unused) default template arguments and arguments from detail
classes.

Note: for the single-argument ctor we don't need to check that C is not
a pointer type, since we know it's an instantiation of the class
template default_copy.