### PR TITLE
Add support for construction from nullptr

### DIFF
--- a/polymorphic_value.h
+++ b/polymorphic_value.h
@@ -283,6 +283,8 @@ class polymorphic_value {
 
   constexpr polymorphic_value() {}
 
+  constexpr polymorphic_value(nullptr_t) {}
+
   template <class U, class C, class D,
             class = std::enable_if_t<std::is_convertible_v<U*, T*>>>
   explicit ISOCPP_P0201_CONSTEXPR_CXX20 polymorphic_value(U* u, C copier,

--- a/polymorphic_value_test.cpp
+++ b/polymorphic_value_test.cpp
@@ -131,6 +131,11 @@ TEST_CASE("Pointer constructor", "[polymorphic_value.constructors]") {
 
     THEN("operator bool returns true") { REQUIRE((bool)ccptr == false); }
   }
+  GIVEN("Ensure polymorphic supports construction from nullptr") {
+    const polymorphic_value<BaseType> ccptr(nullptr);
+
+    THEN("operator bool returns true") { REQUIRE((bool)ccptr == false); }
+  }
 }
 
 struct BaseCloneSelf {


### PR DESCRIPTION
Is seems we specify support for construction from `nullptr` in the [paper](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0201r6.html) but we are missing this function from the implementation.  This change addresses that and ensures we have a test for this feature.